### PR TITLE
fix(plugins): replace raw 🧩 emoji with Icon.Puzzle SVG in Create Plugin button

### DIFF
--- a/js/settings/plugins-tab.js
+++ b/js/settings/plugins-tab.js
@@ -53,8 +53,8 @@ export function populatePluginsTab() {
             <div class="plugin-install-status" id="pluginInstallStatus"></div>
             <div class="plugin-install-hint" style="display: flex; justify-content: space-between; align-items: center;">
                 <span>External plugins use <code>window.AIEditor</code> to access Plugins, EventBus, State, etc.</span>
-                <button type="button" class="btn btn-primary" id="btnCreatePlugin" style="white-space: nowrap; margin-left: 0.5rem;">
-                    🧩 Create Plugin
+                <button type="button" class="btn btn-primary" id="btnCreatePlugin" style="white-space: nowrap; margin-left: 0.5rem;" aria-label="Create a new plugin">
+                    ${Icon.Puzzle} Create Plugin
                 </button>
             </div>
         </div>


### PR DESCRIPTION
### Problem

The "Create Plugin" button uses a raw `🧩` emoji character, which doesn't match the SVG icons used by all sibling buttons (Install, Save, Export JSON, etc.). The emoji has inconsistent size/color/baseline and isn't themeable via CSS custom properties.

### Changes

- Replaced raw `🧩` with `${Icon.Puzzle}` (an inline SVG from the project's Icon module)
- Added `aria-label="Create a new plugin"` for accessibility

### Done criteria

- ✅ Button renders an `<svg>` matching the design system instead of `🧩`
- ✅ Button is visually consistent with `#btnInstallPlugin` in both themes
- ✅ Button has an `aria-label`
- ✅ Plugin install/create flow unchanged (only icon markup changed)

Closes #44